### PR TITLE
chore: bump harden runner action version to 2.13.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: block
           policy: global-allowed-endpoints-policy


### PR DESCRIPTION
This pull request updates a dependency in the GitHub Actions workflow to ensure the latest security improvements are in place. This action version includes bug fixes with policy stores greater than 150 endpoints.

Dependency update:
Updated the step-security/harden-runner GitHub Action from version v2.13.1 to v2.13.2 in the .github/workflows/pipeline.yaml file to incorporate the latest security enhancements.